### PR TITLE
allow getData to query only anatomical data

### DIFF
--- a/test/dummyData/derivatives/SPM12_CPPL/sub-01/ses-01/anat/sub-01_ses-01_T1w.json
+++ b/test/dummyData/derivatives/SPM12_CPPL/sub-01/ses-01/anat/sub-01_ses-01_T1w.json
@@ -1,0 +1,9 @@
+{
+    "Modality": "MR",
+    "RepetitionTime": 2.3,
+    "PhaseEncodingDirection": "j-",
+    "EchoTime": 0.00226,
+    "InversionTime": 0.9,
+    "SliceThickness": 1,
+    "FlipAngle": 8
+}

--- a/test/test_getData.m
+++ b/test/test_getData.m
@@ -53,4 +53,11 @@ assert(group(1).numSub == 5)
 assert(isequal(group(1).subNumber, {'01', 'cont01', 'cat02', 'ctrl02', 'blind01'}))
 
 
+%% Only get anat metadata
+opt.groups = {''};
+opt.subjects = {'01'};
+[~, opt] = getData(opt, [], 'T1w');
+assert(opt.metadata.RepetitionTime == 2.3)
+
+
 end


### PR DESCRIPTION
This should fix the issue #68 but the problem is that because of the way `spm_BIDS` is coded for the moment, the json file with the anat metadata must be stored in the anat folder of the subjects and not only in the dataset root folder.

I think that if we used the `bids_matlab` toolbox instead of the `spm_BIDS` function internal to SPM we would get around this issue but this requires adding a dependency to the pipeline. I am ok with that but managing dependencies with matlab is... well... a pain.

@mohmdrezk what do you think?